### PR TITLE
Rename bridge to relay

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -8,5 +8,5 @@ assignees: ''
 ---
 
 <!--
-Tell us what newer versions of elrond-eth-bridge should include. Add relevant information about why you need the new feature for and why does the existing feature set is not enough. Also, please explain in detailed steps how the feature should work
+Tell us what newer versions of elrond-eth-relay should include. Add relevant information about why you need the new feature for and why does the existing feature set is not enough. Also, please explain in detailed steps how the feature should work
 -->

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,12 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/ElrondNetwork/elrond-eth-bridge/bridge"
+	"github.com/ElrondNetwork/elrond-eth-bridge/relay"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
 	_ "github.com/urfave/cli"
 )
 
-var log = logger.GetOrCreate("eth-bridge")
+var log = logger.GetOrCreate("eth-relay")
 
 func main() {
 	// TODO: get these from the cli
@@ -18,15 +18,15 @@ func main() {
 	elrondSafeAddress := "erd1qqqqqqqqqqqqqpgqfzydqmdw7m2vazsp6u5p95yxz76t2p9rd8ss0zp9ts"
 	elrondPrivateKeyPath := "../mytestnet/testnet/wallets/users/alice.pem"
 
-	log.Debug("Starting bridge")
-	ethToElrBridge, err := bridge.NewBridge(ethNetworkAddress, ethSafeAddress, elrondNetworkAddress, elrondSafeAddress, elrondPrivateKeyPath)
+	log.Debug("Starting relay")
+	ethToElrRelay, err := relay.NewRelay(ethNetworkAddress, ethSafeAddress, elrondNetworkAddress, elrondSafeAddress, elrondPrivateKeyPath)
 
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Println("Bridge started")
+	fmt.Println("Relay started")
 
-	ethToElrBridge.Start(context.Background())
-	defer ethToElrBridge.Stop()
+	ethToElrRelay.Start(context.Background())
+	defer ethToElrRelay.Stop()
 }

--- a/relay/interface.go
+++ b/relay/interface.go
@@ -1,4 +1,4 @@
-package bridge
+package relay
 
 import "context"
 

--- a/relay/relay_test.go
+++ b/relay/relay_test.go
@@ -1,4 +1,4 @@
-package bridge
+package relay
 
 import (
 	"context"
@@ -11,7 +11,7 @@ import (
 
 // implements interface
 var (
-	_ = Startable(&Bridge{})
+	_ = Startable(&Relay{})
 )
 
 type testSafe struct {
@@ -32,7 +32,7 @@ func TestWillBridgeToElrond(t *testing.T) {
 	defer close(ethChannel)
 	ethSafe := &testSafe{ethChannel, nil}
 	elrondSafe := &testSafe{}
-	bridge := Bridge{
+	bridge := Relay{
 		ethSafe:       ethSafe,
 		elrondSafe:    elrondSafe,
 		ethChannel:    ethChannel,


### PR DESCRIPTION
Did a rename for better term use, the entire repo is actually the bridge, the go component is just the relay.