### PR TITLE
Reorg protection

### DIFF
--- a/contracts/ethereum-sc/contracts/ERC20Safe.sol
+++ b/contracts/ethereum-sc/contracts/ERC20Safe.sol
@@ -24,6 +24,7 @@ contract ERC20Safe {
     uint256 public depositsCount;
     uint256 public batchesCount;
     uint256 public batchTimeLimit = 10 minutes;
+    uint256 public batchSettleLimit = 1 minutes;
     // Maximum number of transactions within a batch
     uint256 public batchSize = 10;
     uint256 private constant maxBatchSize = 20;
@@ -158,7 +159,8 @@ contract ERC20Safe {
     function getNextPendingBatch() public view returns (Batch memory) {
         Batch memory batch = batches[currentPendingBatch];
 
-        if((batch.timestamp + batchTimeLimit) < block.timestamp || batch.deposits.length >= batchSize)
+        if(((batch.timestamp + batchTimeLimit) < block.timestamp || batch.deposits.length >= batchSize) 
+            && (batch.lastUpdated + batchSettleLimit) < block.timestamp)
         {
             return batch;
         }

--- a/contracts/ethereum-sc/contracts/ERC20Safe.sol
+++ b/contracts/ethereum-sc/contracts/ERC20Safe.sol
@@ -24,7 +24,7 @@ contract ERC20Safe {
     uint256 public depositsCount;
     uint256 public batchesCount;
     uint256 public batchTimeLimit = 10 minutes;
-    uint256 public batchSettleLimit = 1 minutes;
+    uint256 public batchSettleLimit = 10 minutes;
     // Maximum number of transactions within a batch
     uint256 public batchSize = 10;
     uint256 private constant maxBatchSize = 20;

--- a/contracts/ethereum-sc/contracts/ERC20Safe.sol
+++ b/contracts/ethereum-sc/contracts/ERC20Safe.sol
@@ -154,13 +154,12 @@ contract ERC20Safe {
         - timestamp
         - deposits List of the deposits included in this batch
         @dev This function is to be called by the bridge (which is called by the relayers)
-        It only returns final batches - batches that are full (batchSize) or the block time limit time has passed.
+        It only returns final batches - batches where the block time limit has passed.
     */
     function getNextPendingBatch() public view returns (Batch memory) {
         Batch memory batch = batches[currentPendingBatch];
 
-        if(((batch.timestamp + batchTimeLimit) < block.timestamp || batch.deposits.length >= batchSize) 
-            && (batch.lastUpdated + batchSettleLimit) < block.timestamp)
+        if ((batch.lastUpdated + batchSettleLimit) < block.timestamp)
         {
             return batch;
         }

--- a/contracts/ethereum-sc/contracts/ERC20Safe.sol
+++ b/contracts/ethereum-sc/contracts/ERC20Safe.sol
@@ -116,6 +116,7 @@ contract ERC20Safe {
 
         uint256 depositNonce = depositsCount+1;
         batch.deposits.push(Deposit(depositNonce, tokenAddress, amount, msg.sender, recipientAddress, DepositStatus.Pending));
+        batch.lastUpdated = block.timestamp;
         depositsCount++;
 
         emit ERC20Deposited(depositNonce);
@@ -161,7 +162,7 @@ contract ERC20Safe {
         {
             return batch;
         }
-        return Batch(0, 0, new Deposit[](0));
+        return Batch(0, 0, 0, new Deposit[](0));
     }
 
     /**

--- a/contracts/ethereum-sc/contracts/SharedStructs.sol
+++ b/contracts/ethereum-sc/contracts/SharedStructs.sol
@@ -21,5 +21,6 @@ struct Deposit {
 struct Batch {
     uint256 nonce;
     uint timestamp;
+    uint lastUpdated;
     Deposit[] deposits;
 }

--- a/contracts/ethereum-sc/test/Bridge-test.js
+++ b/contracts/ethereum-sc/test/Bridge-test.js
@@ -34,8 +34,8 @@ describe("Bridge", async function () {
 
   async function settleCurrentBatch() {
     // leave enough time to consider the batch settled (probability for a reorg is minimal)
-    // 1 minute and one second into the future
-    settleTime = (1 * 60) + 1;
+    // 10 minutes and one second into the future
+    settleTime = (10 * 60) + 1;
     await network.provider.send('evm_increaseTime', [settleTime]);
     await network.provider.send("evm_mine")
   }

--- a/contracts/ethereum-sc/test/ERC20Safe-test.js
+++ b/contracts/ethereum-sc/test/ERC20Safe-test.js
@@ -176,7 +176,7 @@ describe("ERC20Safe", async function () {
         expect(await safe.depositsCount.call()).to.equal(1);
       });
 
-      it.only('updates the lastUpdated timestamp on the batch', async function () {
+      it('updates the lastUpdated timestamp on the batch', async function () {
         // Deposit first transaction
         await safe.deposit(afc.address, amount, ethers.utils.toUtf8Bytes("erd13kgks9km5ky8vj2dfty79v769ej433k5xmyhzunk7fv4pndh7z2s8depqq"));
         batchNonce = await await safe.batchesCount.call();

--- a/contracts/ethereum-sc/test/ERC20Safe-test.js
+++ b/contracts/ethereum-sc/test/ERC20Safe-test.js
@@ -1,12 +1,11 @@
 
 const { expect } = require("chai");
-const { waffle } = require("hardhat");
+const { waffle, ethers, network } = require("hardhat");
 const { provider, deployContract } = waffle;
 
 const AFC = require('../artifacts/contracts/AFCoin.sol/AFCoin.json');
 const ERC20Safe = require('../artifacts/contracts/ERC20Safe.sol/ERC20Safe.json');
 const Bridge = require('../artifacts/contracts/Bridge.sol/Bridge.json');
-const { ethers } = require("ethers");
 
 describe("ERC20Safe", async function () {
   const [adminWallet, bridgeWallet, otherWallet] = provider.getWallets();
@@ -176,6 +175,25 @@ describe("ERC20Safe", async function () {
 
         expect(await safe.depositsCount.call()).to.equal(1);
       });
+
+      it.only('updates the lastUpdated timestamp on the batch', async function () {
+        // Deposit first transaction
+        await safe.deposit(afc.address, amount, ethers.utils.toUtf8Bytes("erd13kgks9km5ky8vj2dfty79v769ej433k5xmyhzunk7fv4pndh7z2s8depqq"));
+        batchNonce = await await safe.batchesCount.call();
+        // Get batch after first transaction
+        batch = await safe.getBatch(batchNonce);
+
+        // Incrase time
+        await network.provider.send('evm_increaseTime', [100]);
+        await network.provider.send("evm_mine")
+
+        // Deposit second transaction
+        await safe.deposit(afc.address, amount, ethers.utils.toUtf8Bytes("erd13kgks9km5ky8vj2dfty79v769ej433k5xmyhzunk7fv4pndh7z2s8depqq"));
+        // Get batch after second transaction
+        updatedBatch = await safe.getBatch(batchNonce);
+
+        expect(batch.lastUpdated).to.not.equal(updatedBatch.lastUpdated);
+      })
     });
 
 

--- a/contracts/ethereum-sc/test/ERC20Safe-test.js
+++ b/contracts/ethereum-sc/test/ERC20Safe-test.js
@@ -179,7 +179,7 @@ describe("ERC20Safe", async function () {
       it('updates the lastUpdated timestamp on the batch', async function () {
         // Deposit first transaction
         await safe.deposit(afc.address, amount, ethers.utils.toUtf8Bytes("erd13kgks9km5ky8vj2dfty79v769ej433k5xmyhzunk7fv4pndh7z2s8depqq"));
-        batchNonce = await await safe.batchesCount.call();
+        batchNonce = await safe.batchesCount.call();
         // Get batch after first transaction
         batch = await safe.getBatch(batchNonce);
 


### PR DESCRIPTION
As proposed by @ccorcoveanu this adds another timestamp on the batch.
This is taken into account when a batch is considered final and is taken by the relayers for execution.
This means, that besides the conditions to consider a batch 'full', there's also a need for the batch to 'settle'. 

Currently, the settle threshold is set to 10 minutes.

