### PR TITLE
Deploy eth contract script fix

### DIFF
--- a/contracts/ethereum-sc/scripts/deploy.js
+++ b/contracts/ethereum-sc/scripts/deploy.js
@@ -12,9 +12,11 @@ async function main() {
   // manually to make sure everything is compiled
   // await hre.run('compile');
   // We get the contract to deploy
-  [adminWallet, depositor, relayer1] = await hre.ethers.getSigners();
+  [adminWallet, depositor, relayer1, relayer2, relayer3] = await hre.ethers.getSigners();
   console.log('Admin Public Address:', adminWallet.address);
   console.log('Relayer 1 Public Address:', relayer1.address);
+  console.log('Relayer 2 Public Address:', relayer2.address);
+  console.log('Relayer 3 Public Address:', relayer3.address);
   console.log('Depositor Public Address:', depositor.address);
   // Deploy ERC20 tokens
   const AFC = await hre.ethers.getContractFactory("AFCoin");
@@ -30,14 +32,16 @@ async function main() {
   await safeContract.deployed();
   console.log("ERC20Safe deployed to:", safeContract.address);
   // Whitelist ERC20 tokens in the ERC20 Safe
-  await safeContract.whitelistToken(AFCContract.address);
+  await safeContract.whitelistToken(AFCContract.address, 1);
   // Deploy Bridge with ERC20 Safe address
   const Bridge = await hre.ethers.getContractFactory("Bridge");
   const relayers = [
     adminWallet.address,
-    relayer1.address
+    relayer1.address,
+    relayer2.address,
+    relayer3.address,
   ];
-  const quorum = 1;
+  const quorum = 3;
   const bridgeContract = await Bridge.deploy(relayers, quorum, safeContract.address);
   await bridgeContract.deployed();
   console.log("Bridge deployed to:", bridgeContract.address);


### PR DESCRIPTION
This fixes the error regarding safeContract.whitelistToken call and minimum quorum number.

Adding the relayers addresses as boardMembers directly in the Bridge.deploy is not necessary, but the add-to-whitelist command shall added instead in the README file.