### PR TITLE
Removed pending batch instance from the Ethereum's client

### DIFF
--- a/bridge/elrond/client.go
+++ b/bridge/elrond/client.go
@@ -352,7 +352,7 @@ func (c *client) WasExecuted(_ context.Context, actionId bridge.ActionId, _ brid
 }
 
 // Sign will trigger the execution of a sign operation
-func (c *client) Sign(_ context.Context, actionId bridge.ActionId) (string, error) {
+func (c *client) Sign(_ context.Context, actionId bridge.ActionId, _ *bridge.Batch) (string, error) {
 	builder := newBuilder(c.log).
 		Func("sign").
 		ActionId(actionId)

--- a/bridge/elrond/client_test.go
+++ b/bridge/elrond/client_test.go
@@ -519,7 +519,7 @@ func TestSign(t *testing.T) {
 		proxy := &testProxy{}
 		c, _ := buildTestClient(proxy)
 
-		_, _ = c.Sign(context.TODO(), bridge.NewActionId(42))
+		_, _ = c.Sign(context.TODO(), bridge.NewActionId(42), nil)
 
 		assert.Equal(t, expect, proxy.lastTransaction.GasLimit)
 	})
@@ -527,7 +527,7 @@ func TestSign(t *testing.T) {
 		proxy := &testProxy{transactionCost: 1024}
 		c, _ := buildTestClient(proxy)
 
-		_, _ = c.Sign(context.TODO(), bridge.NewActionId(42))
+		_, _ = c.Sign(context.TODO(), bridge.NewActionId(42), nil)
 
 		assert.Equal(t, []byte("sign@2a"), proxy.lastTransaction.Data)
 	})

--- a/bridge/eth/client_test.go
+++ b/bridge/eth/client_test.go
@@ -123,7 +123,7 @@ func TestSign(t *testing.T) {
 		}
 		broadcaster, client := buildStubs()
 		client.GetActionIdForSetStatusOnPendingTransfer(context.TODO(), batch)
-		_, _ = client.Sign(context.TODO(), bridge.NewActionId(SetStatusAction))
+		_, _ = client.Sign(context.TODO(), bridge.NewActionId(SetStatusAction), batch)
 
 		expectedSignature, _ := hexutil.Decode("0x524957e3081d49d98c98881abd5cf6f737722a4aa0e7915771a567e3cb45cfc625cd9fcf9ec53c86182e517c1e61dbc076722905d11b73e1ed42665ec051342701")
 
@@ -138,7 +138,7 @@ func TestSign(t *testing.T) {
 		}
 		broadcaster, client := buildStubs()
 		client.GetActionIdForSetStatusOnPendingTransfer(context.TODO(), batch)
-		_, _ = client.Sign(context.TODO(), bridge.NewActionId(SetStatusAction))
+		_, _ = client.Sign(context.TODO(), bridge.NewActionId(SetStatusAction), batch)
 
 		expectedSignature, _ := hexutil.Decode("0xd9b1ae38d7e24837e90e7aaac2ae9ca1eb53dc7a30c41774ad7f7f5fd2371c2d0ac6e69643f6aaa25bd9b000dcf0b8be567bcde7f0a5fb5aad122273999bad2500")
 
@@ -158,7 +158,7 @@ func TestSign(t *testing.T) {
 		}
 		broadcaster, client := buildStubs()
 		client.GetActionIdForProposeTransfer(context.TODO(), batch)
-		_, _ = client.Sign(context.TODO(), bridge.NewActionId(TransferAction))
+		_, _ = client.Sign(context.TODO(), bridge.NewActionId(TransferAction), batch)
 		expectedSignature, _ := hexutil.Decode("0xab3ce0cdc229afc9fcd0447800142da85aa116f16a26e151b9cad95b361ab73d24694ded888a06a1e9b731af8a1b549a1fc5188117e40bea11d9e74af4a6d5fa01")
 
 		assert.Equal(t, expectedSignature, broadcaster.lastBroadcastSignature)
@@ -205,7 +205,6 @@ func TestWasExecuted(t *testing.T) {
 		}
 		client := Client{
 			bridgeContract: bcs,
-			pendingBatch:   &bridge.Batch{},
 			broadcaster:    &broadcasterStub{},
 			gasLimit:       GasLimit,
 			log:            logger.GetOrCreate("testEthClient"),
@@ -231,7 +230,6 @@ func TestExecute(t *testing.T) {
 			publicKey:        publicKey(t),
 			broadcaster:      &broadcasterStub{},
 			blockchainClient: &blockchainClientStub{},
-			pendingBatch:     &bridge.Batch{},
 			log:              logger.GetOrCreate("testEthClient"),
 			gasLimit:         GasLimit,
 		}
@@ -255,14 +253,8 @@ func TestExecute(t *testing.T) {
 			broadcaster:      &broadcasterStub{},
 			mapper:           &mapperStub{},
 			blockchainClient: &blockchainClientStub{},
-			pendingBatch: &bridge.Batch{
-				Id: bridge.NewBatchId(42),
-				Transactions: []*bridge.DepositTransaction{{
-					TokenAddress: "0x574554482d323936313238",
-				}},
-			},
-			gasLimit: GasLimit,
-			log:      logger.GetOrCreate("testEthClient"),
+			gasLimit:         GasLimit,
+			log:              logger.GetOrCreate("testEthClient"),
 		}
 		batch := &bridge.Batch{Id: bridge.NewBatchId(42)}
 

--- a/bridge/interface.go
+++ b/bridge/interface.go
@@ -44,7 +44,7 @@ type Bridge interface {
 	WasProposedSetStatus(context.Context, *Batch) bool
 	GetActionIdForSetStatusOnPendingTransfer(context.Context, *Batch) ActionId
 	WasExecuted(context.Context, ActionId, BatchId) bool
-	Sign(context.Context, ActionId) (string, error)
+	Sign(context.Context, ActionId, *Batch) (string, error)
 	Execute(context.Context, ActionId, *Batch) (string, error)
 	SignersCount(context.Context, ActionId) uint
 	GetTransactionsStatuses(ctx context.Context, batchID BatchId) ([]uint8, error)

--- a/ethToElrond/bridgeExecutors/ethElrondBridgeExecutor.go
+++ b/ethToElrond/bridgeExecutors/ethElrondBridgeExecutor.go
@@ -255,7 +255,7 @@ func (executor *ethElrondBridgeExecutor) isStatusesCheckOnDestinationNeeded() bo
 func (executor *ethElrondBridgeExecutor) SignProposeTransferOnDestination(ctx context.Context) {
 	executor.logger.Info(executor.appendMessageToName("signing propose transfer"), "batch ID", executor.getBatchID())
 	executor.actionID = executor.destinationBridge.GetActionIdForProposeTransfer(ctx, executor.pendingBatch)
-	_, err := executor.destinationBridge.Sign(ctx, executor.actionID)
+	_, err := executor.destinationBridge.Sign(ctx, executor.actionID, executor.pendingBatch)
 	if err != nil {
 		executor.logger.Error(executor.appendMessageToName(err.Error()))
 	}
@@ -265,7 +265,7 @@ func (executor *ethElrondBridgeExecutor) SignProposeTransferOnDestination(ctx co
 func (executor *ethElrondBridgeExecutor) SignProposeSetStatusOnSource(ctx context.Context) {
 	executor.logger.Info(executor.appendMessageToName("signing set status"), "batch ID", executor.getBatchID())
 	executor.actionID = executor.sourceBridge.GetActionIdForSetStatusOnPendingTransfer(ctx, executor.pendingBatch)
-	_, err := executor.sourceBridge.Sign(ctx, executor.actionID)
+	_, err := executor.sourceBridge.Sign(ctx, executor.actionID, executor.pendingBatch)
 	if err != nil {
 		executor.logger.Error(executor.appendMessageToName(err.Error()))
 	}

--- a/ethToElrond/bridgeExecutors/mock/bridgeStub.go
+++ b/ethToElrond/bridgeExecutors/mock/bridgeStub.go
@@ -116,7 +116,7 @@ func (b *BridgeStub) GetActionIdForSetStatusOnPendingTransfer(ctx context.Contex
 }
 
 // Sign -
-func (b *BridgeStub) Sign(ctx context.Context, id bridge.ActionId) (string, error) {
+func (b *BridgeStub) Sign(ctx context.Context, id bridge.ActionId, _ *bridge.Batch) (string, error) {
 	b.incrementFunctionCounter()
 	if b.SignCalled != nil {
 		return b.SignCalled(ctx, id)

--- a/integrationTests/mock/bridgeMock.go
+++ b/integrationTests/mock/bridgeMock.go
@@ -131,7 +131,7 @@ func (bm *BridgeMock) WasExecuted(_ context.Context, id bridge.ActionId, id2 bri
 }
 
 // Sign -
-func (bm *BridgeMock) Sign(_ context.Context, id bridge.ActionId) (string, error) {
+func (bm *BridgeMock) Sign(_ context.Context, id bridge.ActionId, _ *bridge.Batch) (string, error) {
 	bm.Lock()
 	defer bm.Unlock()
 

--- a/relay/bridgeMock.go
+++ b/relay/bridgeMock.go
@@ -99,7 +99,7 @@ func (b *bridgeMock) WasExecuted(_ context.Context, _ bridge.ActionId, _ bridge.
 }
 
 // Sign -
-func (b *bridgeMock) Sign(_ context.Context, actionId bridge.ActionId) (string, error) {
+func (b *bridgeMock) Sign(_ context.Context, actionId bridge.ActionId, _ *bridge.Batch) (string, error) {
 	b.Lock()
 	defer b.Unlock()
 


### PR DESCRIPTION
- removed the pending batch from the Ethereum client and instead use the executor's pending batch. This is required so the clients (both Elrond's and Ethereum's) will be stateless regarding the execution batch. Otherwise the values might get changed whenever both bridges execute batches in the same time. Only the executor instances should keep the current batch. 