### PR TITLE
Extracted the functionality from relay AmITheLeader() to a new component

### DIFF
--- a/core/topology/errors.go
+++ b/core/topology/errors.go
@@ -5,8 +5,8 @@ import (
 )
 
 var (
-    ErrNilSortedPublicKeys = errors.New("nil sorted public keys")
-    ErrInvalidStepDuration = errors.New("invalid step duration")
-    ErrNilTimer            = errors.New("nil timer")
-    ErrNilAddress          = errors.New("nil address")
+    errNilSortedPublicKeys = errors.New("nil sorted public keys")
+    errInvalidStepDuration = errors.New("invalid step duration")
+    errNilTimer            = errors.New("nil timer")
+    errNilAddress          = errors.New("nil address")
 )

--- a/core/topology/errors.go
+++ b/core/topology/errors.go
@@ -1,0 +1,12 @@
+package topology
+
+import (
+    "errors"
+)
+
+var (
+    ErrNilSortedPublicKeys = errors.New("nil sorted public keys")
+    ErrInvalidStepDuration = errors.New("invalid step duration")
+    ErrNilTimer            = errors.New("nil timer")
+    ErrNilAddress          = errors.New("nil address")
+)

--- a/core/topology/topologyHandler.go
+++ b/core/topology/topologyHandler.go
@@ -1,0 +1,51 @@
+package topology
+
+import (
+    "bytes"
+    "time"
+
+    "github.com/ElrondNetwork/elrond-eth-bridge/core"
+)
+
+// ArgsTopologyHandler is the DTO used in the NewTopologyHandler constructor function
+type ArgsTopologyHandler struct {
+    SortedPublicKeys [][]byte
+    Timer            core.Timer
+    StepDuration     time.Duration
+    Address          []byte
+}
+
+// topologyHandler implements topologyProvider for a specific relay
+type topologyHandler struct {
+    sortedPublicKeys [][]byte
+    timer            core.Timer
+    stepDuration     time.Duration
+    address          []byte
+}
+
+// NewTopologyHandler creates a new topologyHandler instance
+func NewTopologyHandler(args ArgsTopologyHandler) *topologyHandler {
+    return &topologyHandler{
+        sortedPublicKeys: args.SortedPublicKeys,
+        timer:            args.Timer,
+        stepDuration:     args.StepDuration,
+        address:          args.Address,
+    }
+}
+
+// MyTurnAsLeader returns true if the current relay is leader
+func (t *topologyHandler) MyTurnAsLeader() bool {
+    if len(t.sortedPublicKeys) == 0 {
+        return false
+    } else {
+        numberOfPeers := int64(len(t.sortedPublicKeys))
+        index := (t.timer.NowUnix() / int64(t.stepDuration.Seconds())) % numberOfPeers
+
+        return bytes.Equal(t.sortedPublicKeys[index], t.address)
+    }
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (t *topologyHandler) IsInterfaceNil() bool {
+    return t == nil
+}

--- a/core/topology/topologyHandler.go
+++ b/core/topology/topologyHandler.go
@@ -58,16 +58,16 @@ func (t *topologyHandler) IsInterfaceNil() bool {
 
 func checkArgs(args ArgsTopologyHandler) error {
     if args.SortedPublicKeys == nil {
-        return ErrNilSortedPublicKeys
+        return errNilSortedPublicKeys
     }
     if check.IfNil(args.Timer) {
-        return ErrNilTimer
+        return errNilTimer
     }
     if int64(args.StepDuration.Seconds()) <= 0 {
-        return ErrInvalidStepDuration
+        return errInvalidStepDuration
     }
     if args.Address == nil {
-        return ErrNilAddress
+        return errNilAddress
     }
 
     return nil

--- a/core/topology/topologyHandler.go
+++ b/core/topology/topologyHandler.go
@@ -5,6 +5,7 @@ import (
     "time"
 
     "github.com/ElrondNetwork/elrond-eth-bridge/core"
+    "github.com/ElrondNetwork/elrond-go-core/core/check"
 )
 
 // ArgsTopologyHandler is the DTO used in the NewTopologyHandler constructor function
@@ -24,13 +25,18 @@ type topologyHandler struct {
 }
 
 // NewTopologyHandler creates a new topologyHandler instance
-func NewTopologyHandler(args ArgsTopologyHandler) *topologyHandler {
+func NewTopologyHandler(args ArgsTopologyHandler) (*topologyHandler, error) {
+    err := checkArgs(args)
+    if err != nil {
+        return nil, err
+    }
+
     return &topologyHandler{
         sortedPublicKeys: args.SortedPublicKeys,
         timer:            args.Timer,
         stepDuration:     args.StepDuration,
         address:          args.Address,
-    }
+    }, nil
 }
 
 // MyTurnAsLeader returns true if the current relay is leader
@@ -48,4 +54,21 @@ func (t *topologyHandler) MyTurnAsLeader() bool {
 // IsInterfaceNil returns true if there is no value under the interface
 func (t *topologyHandler) IsInterfaceNil() bool {
     return t == nil
+}
+
+func checkArgs(args ArgsTopologyHandler) error {
+    if args.SortedPublicKeys == nil {
+        return ErrNilSortedPublicKeys
+    }
+    if check.IfNil(args.Timer) {
+        return ErrNilTimer
+    }
+    if int64(args.StepDuration.Seconds()) <= 0 {
+        return ErrInvalidStepDuration
+    }
+    if args.Address == nil {
+        return ErrNilAddress
+    }
+
+    return nil
 }

--- a/core/topology/topologyHandler_test.go
+++ b/core/topology/topologyHandler_test.go
@@ -8,7 +8,7 @@ import (
     "github.com/stretchr/testify/assert"
 )
 
-var duration = time.Duration(1000000000) // one sec
+var duration = time.Second
 
 func TestNewTopologyHandler(t *testing.T) {
     t.Parallel()
@@ -36,7 +36,7 @@ func TestNewTopologyHandler(t *testing.T) {
     })
 
     t.Run("nil providedSortedPublicKeys", func(t *testing.T) {
-        expectedErr := ErrNilSortedPublicKeys
+        expectedErr := errNilSortedPublicKeys
         args := ArgsTopologyHandler{}
         tph, err := NewTopologyHandler(args)
         assert.Nil(t, tph)
@@ -44,7 +44,7 @@ func TestNewTopologyHandler(t *testing.T) {
     })
 
     t.Run("nil timer", func(t *testing.T) {
-        expectedErr := ErrNilTimer
+        expectedErr := errNilTimer
         args := ArgsTopologyHandler{}
         args.SortedPublicKeys = [][]byte{[]byte("abc")}
         tph, err := NewTopologyHandler(args)
@@ -53,7 +53,7 @@ func TestNewTopologyHandler(t *testing.T) {
     })
 
     t.Run("invalid step duration", func(t *testing.T) {
-        expectedErr := ErrInvalidStepDuration
+        expectedErr := errInvalidStepDuration
         args := ArgsTopologyHandler{
             SortedPublicKeys: [][]byte{[]byte("abc")},
             Timer:            createTimerStubWithUnixValue(0),
@@ -65,7 +65,7 @@ func TestNewTopologyHandler(t *testing.T) {
     })
 
     t.Run("nil address", func(t *testing.T) {
-        expectedErr := ErrNilAddress
+        expectedErr := errNilAddress
         args := ArgsTopologyHandler{
             SortedPublicKeys: [][]byte{[]byte("abc")},
             Timer:            createTimerStubWithUnixValue(0),

--- a/core/topology/topologyHandler_test.go
+++ b/core/topology/topologyHandler_test.go
@@ -1,0 +1,90 @@
+package topology
+
+import (
+    "testing"
+    "time"
+
+    "github.com/ElrondNetwork/elrond-eth-bridge/core"
+    "github.com/ElrondNetwork/elrond-eth-bridge/testsCommon"
+    "github.com/stretchr/testify/assert"
+)
+
+func TestNewTopologyHandler(t *testing.T) {
+    t.Parallel()
+
+    providedSortedPublicKeys := make([][]byte, 0)
+    providedTimer := core.Timer(nil)
+    providedAddress := make([]byte, 0)
+    providedStepDuration := time.Duration(0)
+    args := ArgsTopologyHandler{
+        SortedPublicKeys: providedSortedPublicKeys,
+        Timer:            providedTimer,
+        Address:          providedAddress,
+        StepDuration:     providedStepDuration,
+    }
+    tph := NewTopologyHandler(args)
+    assert.NotNil(t, tph)                 // pointer check
+    assert.False(t, tph.IsInterfaceNil()) // IsInterfaceNIl
+
+    assert.Equal(t, providedSortedPublicKeys, tph.sortedPublicKeys)
+    assert.Equal(t, providedTimer, tph.timer)
+    assert.Equal(t, providedAddress, tph.address)
+    assert.Equal(t, providedStepDuration, tph.stepDuration)
+}
+
+func TestMyTurnAsLeader(t *testing.T) {
+    t.Parallel()
+
+    t.Run("not leader - SortedPublicKeys empty", func(t *testing.T) {
+        args := ArgsTopologyHandler{
+            SortedPublicKeys: nil,
+            Timer:            nil,
+            Address:          nil,
+            StepDuration:     0,
+        }
+        tph := NewTopologyHandler(args)
+
+        assert.False(t, tph.MyTurnAsLeader())
+    })
+
+    t.Run("not leader", func(t *testing.T) {
+        providedSortedPublicKeys := [][]byte{[]byte("aaa"), []byte("bbb")} // numberOfPeers = 2
+        providedTimer := testsCommon.NewTimerStub()
+        providedTimer.NowUnixCalled = func() int64 {
+            return 0
+        }
+        providedAddress := []byte("ccc")
+        providedStepDuration := time.Duration(1000000000) // one second
+        args := ArgsTopologyHandler{
+            SortedPublicKeys: providedSortedPublicKeys,
+            Timer:            providedTimer,
+            Address:          providedAddress,
+            StepDuration:     providedStepDuration,
+        }
+        tph := NewTopologyHandler(args)
+
+        // 0/1%2=0 -> providedSortedPublicKeys[0] != providedAddress -> not leader
+        assert.False(t, tph.MyTurnAsLeader())
+    })
+
+    t.Run("leader", func(t *testing.T) {
+        expectedLeader := []byte("aaa")
+        providedSortedPublicKeys := [][]byte{expectedLeader, []byte("bbb")} // numberOfPeers = 2
+        providedTimer := testsCommon.NewTimerStub()
+        providedTimer.NowUnixCalled = func() int64 {
+            return 0
+        }
+        providedAddress := expectedLeader
+        providedStepDuration := time.Duration(1000000000) // one second
+        args := ArgsTopologyHandler{
+            SortedPublicKeys: providedSortedPublicKeys,
+            Timer:            providedTimer,
+            Address:          providedAddress,
+            StepDuration:     providedStepDuration,
+        }
+        tph := NewTopologyHandler(args)
+
+        // index=0/1%2=0 -> providedSortedPublicKeys[0] == providedAddress -> leader
+        assert.True(t, tph.MyTurnAsLeader())
+    })
+}

--- a/core/topology/topologyHandler_test.go
+++ b/core/topology/topologyHandler_test.go
@@ -4,32 +4,77 @@ import (
     "testing"
     "time"
 
-    "github.com/ElrondNetwork/elrond-eth-bridge/core"
     "github.com/ElrondNetwork/elrond-eth-bridge/testsCommon"
     "github.com/stretchr/testify/assert"
 )
 
+var duration = time.Duration(1000000000) // one sec
+
 func TestNewTopologyHandler(t *testing.T) {
     t.Parallel()
 
-    providedSortedPublicKeys := make([][]byte, 0)
-    providedTimer := core.Timer(nil)
-    providedAddress := make([]byte, 0)
-    providedStepDuration := time.Duration(0)
-    args := ArgsTopologyHandler{
-        SortedPublicKeys: providedSortedPublicKeys,
-        Timer:            providedTimer,
-        Address:          providedAddress,
-        StepDuration:     providedStepDuration,
-    }
-    tph := NewTopologyHandler(args)
-    assert.NotNil(t, tph)                 // pointer check
-    assert.False(t, tph.IsInterfaceNil()) // IsInterfaceNIl
+    t.Run("should work", func(t *testing.T) {
+        providedSortedPublicKeys := [][]byte{[]byte("aaa"), []byte("bbb")}
+        providedTimer := createTimerStubWithUnixValue(123)
+        providedAddress := []byte("aaa")
+        providedStepDuration := duration
+        args := ArgsTopologyHandler{
+            SortedPublicKeys: providedSortedPublicKeys,
+            Timer:            providedTimer,
+            Address:          providedAddress,
+            StepDuration:     providedStepDuration,
+        }
+        tph, err := NewTopologyHandler(args)
+        assert.NotNil(t, tph) // pointer check
+        assert.Nil(t, err)
+        assert.False(t, tph.IsInterfaceNil()) // IsInterfaceNIl
 
-    assert.Equal(t, providedSortedPublicKeys, tph.sortedPublicKeys)
-    assert.Equal(t, providedTimer, tph.timer)
-    assert.Equal(t, providedAddress, tph.address)
-    assert.Equal(t, providedStepDuration, tph.stepDuration)
+        assert.Equal(t, providedSortedPublicKeys, tph.sortedPublicKeys)
+        assert.Equal(t, providedTimer, tph.timer)
+        assert.Equal(t, providedAddress, tph.address)
+        assert.Equal(t, providedStepDuration, tph.stepDuration)
+    })
+
+    t.Run("nil providedSortedPublicKeys", func(t *testing.T) {
+        expectedErr := ErrNilSortedPublicKeys
+        args := ArgsTopologyHandler{}
+        tph, err := NewTopologyHandler(args)
+        assert.Nil(t, tph)
+        assert.Equal(t, expectedErr, err)
+    })
+
+    t.Run("nil timer", func(t *testing.T) {
+        expectedErr := ErrNilTimer
+        args := ArgsTopologyHandler{}
+        args.SortedPublicKeys = [][]byte{[]byte("abc")}
+        tph, err := NewTopologyHandler(args)
+        assert.Nil(t, tph)
+        assert.Equal(t, expectedErr, err)
+    })
+
+    t.Run("invalid step duration", func(t *testing.T) {
+        expectedErr := ErrInvalidStepDuration
+        args := ArgsTopologyHandler{
+            SortedPublicKeys: [][]byte{[]byte("abc")},
+            Timer:            createTimerStubWithUnixValue(0),
+            StepDuration:     time.Duration(12345),
+        }
+        tph, err := NewTopologyHandler(args)
+        assert.Nil(t, tph)
+        assert.Equal(t, expectedErr, err)
+    })
+
+    t.Run("nil address", func(t *testing.T) {
+        expectedErr := ErrNilAddress
+        args := ArgsTopologyHandler{
+            SortedPublicKeys: [][]byte{[]byte("abc")},
+            Timer:            createTimerStubWithUnixValue(0),
+            StepDuration:     duration,
+        }
+        tph, err := NewTopologyHandler(args)
+        assert.Nil(t, tph)
+        assert.Equal(t, expectedErr, err)
+    })
 }
 
 func TestMyTurnAsLeader(t *testing.T) {
@@ -37,31 +82,24 @@ func TestMyTurnAsLeader(t *testing.T) {
 
     t.Run("not leader - SortedPublicKeys empty", func(t *testing.T) {
         args := ArgsTopologyHandler{
-            SortedPublicKeys: nil,
-            Timer:            nil,
-            Address:          nil,
-            StepDuration:     0,
+            SortedPublicKeys: [][]byte{},
+            Timer:            createTimerStubWithUnixValue(0),
+            Address:          []byte("abc"),
+            StepDuration:     duration,
         }
-        tph := NewTopologyHandler(args)
+        tph, _ := NewTopologyHandler(args)
 
         assert.False(t, tph.MyTurnAsLeader())
     })
 
     t.Run("not leader", func(t *testing.T) {
-        providedSortedPublicKeys := [][]byte{[]byte("aaa"), []byte("bbb")} // numberOfPeers = 2
-        providedTimer := testsCommon.NewTimerStub()
-        providedTimer.NowUnixCalled = func() int64 {
-            return 0
-        }
-        providedAddress := []byte("ccc")
-        providedStepDuration := time.Duration(1000000000) // one second
         args := ArgsTopologyHandler{
-            SortedPublicKeys: providedSortedPublicKeys,
-            Timer:            providedTimer,
-            Address:          providedAddress,
-            StepDuration:     providedStepDuration,
+            SortedPublicKeys: [][]byte{[]byte("aaa"), []byte("bbb")}, // numberOfPeers = 2
+            Timer:            createTimerStubWithUnixValue(0),
+            Address:          []byte("ccc"),
+            StepDuration:     duration,
         }
-        tph := NewTopologyHandler(args)
+        tph, _ := NewTopologyHandler(args)
 
         // 0/1%2=0 -> providedSortedPublicKeys[0] != providedAddress -> not leader
         assert.False(t, tph.MyTurnAsLeader())
@@ -69,22 +107,23 @@ func TestMyTurnAsLeader(t *testing.T) {
 
     t.Run("leader", func(t *testing.T) {
         expectedLeader := []byte("aaa")
-        providedSortedPublicKeys := [][]byte{expectedLeader, []byte("bbb")} // numberOfPeers = 2
-        providedTimer := testsCommon.NewTimerStub()
-        providedTimer.NowUnixCalled = func() int64 {
-            return 0
-        }
-        providedAddress := expectedLeader
-        providedStepDuration := time.Duration(1000000000) // one second
         args := ArgsTopologyHandler{
-            SortedPublicKeys: providedSortedPublicKeys,
-            Timer:            providedTimer,
-            Address:          providedAddress,
-            StepDuration:     providedStepDuration,
+            SortedPublicKeys: [][]byte{expectedLeader, []byte("bbb")}, // numberOfPeers = 2
+            Timer:            createTimerStubWithUnixValue(0),
+            Address:          expectedLeader,
+            StepDuration:     duration,
         }
-        tph := NewTopologyHandler(args)
+        tph, _ := NewTopologyHandler(args)
 
         // index=0/1%2=0 -> providedSortedPublicKeys[0] == providedAddress -> leader
         assert.True(t, tph.MyTurnAsLeader())
     })
+}
+
+func createTimerStubWithUnixValue(value int64) *testsCommon.TimerStub {
+    stub := testsCommon.NewTimerStub()
+    stub.NowUnixCalled = func() int64 {
+        return value
+    }
+    return stub
 }

--- a/core/topology/topologyHandler_test.go
+++ b/core/topology/topologyHandler_test.go
@@ -4,7 +4,6 @@ import (
     "testing"
     "time"
 
-    "github.com/ElrondNetwork/elrond-eth-bridge/core"
     "github.com/ElrondNetwork/elrond-eth-bridge/testsCommon"
     "github.com/stretchr/testify/assert"
 )
@@ -15,47 +14,53 @@ func TestNewTopologyHandler(t *testing.T) {
     t.Parallel()
 
     t.Run("should work", func(t *testing.T) {
-        providedSortedPublicKeys := [][]byte{[]byte("aaa"), []byte("bbb")}
-        providedTimer := createTimerStubWithUnixValue(123)
-        providedAddress := []byte("aaa")
-        providedStepDuration := duration
-        tph, err := createTopologyHandler(providedSortedPublicKeys, providedTimer, providedStepDuration, providedAddress)
+        args := createMockArgsTopologyHandler()
+        tph, err := NewTopologyHandler(args)
+
         assert.NotNil(t, tph) // pointer check
         assert.Nil(t, err)
         assert.False(t, tph.IsInterfaceNil()) // IsInterfaceNIl
 
-        assert.Equal(t, providedSortedPublicKeys, tph.sortedPublicKeys)
-        assert.Equal(t, providedTimer, tph.timer)
-        assert.Equal(t, providedAddress, tph.address)
-        assert.Equal(t, providedStepDuration, tph.stepDuration)
+        assert.Equal(t, args.SortedPublicKeys, tph.sortedPublicKeys)
+        assert.Equal(t, args.Timer, tph.timer)
+        assert.Equal(t, args.StepDuration, tph.stepDuration)
+        assert.Equal(t, args.Address, tph.address)
     })
 
     t.Run("nil providedSortedPublicKeys", func(t *testing.T) {
-        expectedErr := errNilSortedPublicKeys
-        tph, err := createTopologyHandler(nil, nil, 0, nil)
+        args := createMockArgsTopologyHandler()
+        args.SortedPublicKeys = nil
+        tph, err := NewTopologyHandler(args)
+
         assert.Nil(t, tph)
-        assert.Equal(t, expectedErr, err)
+        assert.Equal(t, errNilSortedPublicKeys, err)
     })
 
     t.Run("nil timer", func(t *testing.T) {
-        expectedErr := errNilTimer
-        tph, err := createTopologyHandler([][]byte{[]byte("abc")}, nil, 0, nil)
+        args := createMockArgsTopologyHandler()
+        args.Timer = nil
+        tph, err := NewTopologyHandler(args)
+
         assert.Nil(t, tph)
-        assert.Equal(t, expectedErr, err)
+        assert.Equal(t, errNilTimer, err)
     })
 
     t.Run("invalid step duration", func(t *testing.T) {
-        expectedErr := errInvalidStepDuration
-        tph, err := createTopologyHandler([][]byte{[]byte("abc")}, createTimerStubWithUnixValue(0), time.Duration(12345), nil)
+        args := createMockArgsTopologyHandler()
+        args.StepDuration = time.Duration(12345)
+        tph, err := NewTopologyHandler(args)
+
         assert.Nil(t, tph)
-        assert.Equal(t, expectedErr, err)
+        assert.Equal(t, errInvalidStepDuration, err)
     })
 
     t.Run("nil address", func(t *testing.T) {
-        expectedErr := errNilAddress
-        tph, err := createTopologyHandler([][]byte{[]byte("abc")}, createTimerStubWithUnixValue(0), duration, nil)
+        args := createMockArgsTopologyHandler()
+        args.Address = nil
+        tph, err := NewTopologyHandler(args)
+
         assert.Nil(t, tph)
-        assert.Equal(t, expectedErr, err)
+        assert.Equal(t, errNilAddress, err)
     })
 }
 
@@ -63,20 +68,25 @@ func TestMyTurnAsLeader(t *testing.T) {
     t.Parallel()
 
     t.Run("not leader - SortedPublicKeys empty", func(t *testing.T) {
-        tph, _ := createTopologyHandler([][]byte{}, createTimerStubWithUnixValue(0), duration, []byte("abc"))
+        args := createMockArgsTopologyHandler()
+        args.SortedPublicKeys = [][]byte{}
+        tph, _ := NewTopologyHandler(args)
+
         assert.False(t, tph.MyTurnAsLeader())
     })
 
     t.Run("not leader", func(t *testing.T) {
-        tph, _ := createTopologyHandler([][]byte{[]byte("aaa"), []byte("bbb")}, createTimerStubWithUnixValue(0), duration, []byte("abc"))
+        args := createMockArgsTopologyHandler()
+        args.Address = []byte("abc")
+        tph, _ := NewTopologyHandler(args)
 
         // 0/1%2=0 -> providedSortedPublicKeys[0] != providedAddress -> not leader
         assert.False(t, tph.MyTurnAsLeader())
     })
 
     t.Run("leader", func(t *testing.T) {
-        expectedLeader := []byte("aaa")
-        tph, _ := createTopologyHandler([][]byte{expectedLeader, []byte("bbb")}, createTimerStubWithUnixValue(0), duration, expectedLeader)
+        args := createMockArgsTopologyHandler()
+        tph, _ := NewTopologyHandler(args)
 
         // index=0/1%2=0 -> providedSortedPublicKeys[0] == providedAddress -> leader
         assert.True(t, tph.MyTurnAsLeader())
@@ -91,12 +101,11 @@ func createTimerStubWithUnixValue(value int64) *testsCommon.TimerStub {
     return stub
 }
 
-func createTopologyHandler(pk [][]byte, timer core.Timer, duration time.Duration, address []byte) (*topologyHandler, error) {
-    args := ArgsTopologyHandler{
-        SortedPublicKeys: pk,
-        Timer:            timer,
+func createMockArgsTopologyHandler() ArgsTopologyHandler {
+    return ArgsTopologyHandler{
+        SortedPublicKeys: [][]byte{[]byte("aaa"), []byte("bbb")},
+        Timer:            createTimerStubWithUnixValue(0),
         StepDuration:     duration,
-        Address:          address,
+        Address:          []byte("aaa"),
     }
-    return NewTopologyHandler(args)
 }


### PR DESCRIPTION
Created `topologyHandler` which implements `topologyProvider` and has the same functionality as old relay `AmITheLeader()` on `MyTurnAsLeader()`