### PR TITLE
Improvements

### DIFF
--- a/bridges/ethElrond/steps/elrondToEth/step01GetPending.go
+++ b/bridges/ethElrond/steps/elrondToEth/step01GetPending.go
@@ -37,7 +37,7 @@ func (step *getPendingStep) Execute(ctx context.Context) core.StepIdentifier {
 	isValid, err := step.bridge.ValidateBatch(ctx, batch)
 	if err != nil {
 		body, _ := json.Marshal(batch)
-		step.bridge.PrintInfo(logger.LogError, "error validating Elrond batch", "error", err, "batch", body)
+		step.bridge.PrintInfo(logger.LogError, "error validating Elrond batch", "error", err, "batch", string(body))
 		return step.Identifier()
 	}
 

--- a/clients/batchValidator/batchValidator.go
+++ b/clients/batchValidator/batchValidator.go
@@ -40,7 +40,7 @@ func NewBatchValidator(args ArgsBatchValidator) (*batchValidator, error) {
 	}
 
 	bv := &batchValidator{
-		requestURL:  args.RequestURL + "/" + string(args.SourceChain) + "/" + string(args.DestinationChain),
+		requestURL:  fmt.Sprintf("%s/%s/%s", args.RequestURL, args.SourceChain, args.DestinationChain),
 		requestTime: args.RequestTime,
 		httpClient:  http.DefaultClient,
 	}

--- a/clients/elrond/client.go
+++ b/clients/elrond/client.go
@@ -195,7 +195,7 @@ func (c *client) createPendingBatchFromResponse(ctx context.Context, responseDat
 		ID: batchID,
 	}
 
-	tokens := make(map[string][]byte)
+	cachedTokens := make(map[string][]byte)
 	transferIndex := 0
 	for i := 1; i < dataLen; i += numFieldsForTransaction {
 		// blockNonce is the i-th element, let's ignore it for now
@@ -216,15 +216,15 @@ func (c *client) createPendingBatchFromResponse(ctx context.Context, responseDat
 			Amount:           amount,
 		}
 
-		contractAddress, exists := tokens[deposit.DisplayableToken]
+		storedConvertedTokenBytes, exists := cachedTokens[deposit.DisplayableToken]
 		if !exists {
 			deposit.ConvertedTokenBytes, err = c.tokensMapper.ConvertToken(ctx, deposit.TokenBytes)
 			if err != nil {
 				return nil, fmt.Errorf("%w while converting token bytes, transfer index %d", err, transferIndex)
 			}
-			tokens[deposit.DisplayableToken] = deposit.ConvertedTokenBytes
+			cachedTokens[deposit.DisplayableToken] = deposit.ConvertedTokenBytes
 		} else {
-			deposit.ConvertedTokenBytes = contractAddress
+			deposit.ConvertedTokenBytes = storedConvertedTokenBytes
 		}
 
 		batch.Deposits = append(batch.Deposits, deposit)

--- a/clients/elrond/client.go
+++ b/clients/elrond/client.go
@@ -195,6 +195,7 @@ func (c *client) createPendingBatchFromResponse(ctx context.Context, responseDat
 		ID: batchID,
 	}
 
+	tokens := make(map[string][]byte)
 	transferIndex := 0
 	for i := 1; i < dataLen; i += numFieldsForTransaction {
 		// blockNonce is the i-th element, let's ignore it for now
@@ -215,9 +216,15 @@ func (c *client) createPendingBatchFromResponse(ctx context.Context, responseDat
 			Amount:           amount,
 		}
 
-		deposit.ConvertedTokenBytes, err = c.tokensMapper.ConvertToken(ctx, deposit.TokenBytes)
-		if err != nil {
-			return nil, fmt.Errorf("%w while converting token bytes, transfer index %d", err, transferIndex)
+		contractAddress, exists := tokens[deposit.DisplayableToken]
+		if !exists {
+			deposit.ConvertedTokenBytes, err = c.tokensMapper.ConvertToken(ctx, deposit.TokenBytes)
+			if err != nil {
+				return nil, fmt.Errorf("%w while converting token bytes, transfer index %d", err, transferIndex)
+			}
+			tokens[deposit.DisplayableToken] = deposit.ConvertedTokenBytes
+		} else {
+			deposit.ConvertedTokenBytes = contractAddress
 		}
 
 		batch.Deposits = append(batch.Deposits, deposit)

--- a/clients/ethereum/client.go
+++ b/clients/ethereum/client.go
@@ -148,7 +148,7 @@ func (c *client) GetBatch(ctx context.Context, nonce uint64) (*clients.TransferB
 		ID:       batch.Nonce.Uint64(),
 		Deposits: make([]*clients.DepositTransfer, 0, batch.DepositsCount),
 	}
-	tokens := make(map[string][]byte)
+	cachedTokens := make(map[string][]byte)
 	for i := range deposits {
 		deposit := deposits[i]
 		toBytes := deposit.Recipient[:]
@@ -165,15 +165,15 @@ func (c *client) GetBatch(ctx context.Context, nonce uint64) (*clients.TransferB
 			DisplayableToken: c.addressConverter.ToHexString(tokenBytes),
 			Amount:           big.NewInt(0).Set(deposit.Amount),
 		}
-		contractAddress, exists := tokens[depositTransfer.DisplayableToken]
+		storedConvertedTokenBytes, exists := cachedTokens[depositTransfer.DisplayableToken]
 		if !exists {
 			depositTransfer.ConvertedTokenBytes, err = c.tokensMapper.ConvertToken(ctx, depositTransfer.TokenBytes)
 			if err != nil {
 				return nil, err
 			}
-			tokens[depositTransfer.DisplayableToken] = depositTransfer.ConvertedTokenBytes
+			cachedTokens[depositTransfer.DisplayableToken] = depositTransfer.ConvertedTokenBytes
 		} else {
-			depositTransfer.ConvertedTokenBytes = contractAddress
+			depositTransfer.ConvertedTokenBytes = storedConvertedTokenBytes
 		}
 
 		transferBatch.Deposits = append(transferBatch.Deposits, depositTransfer)

--- a/clients/ethereum/client.go
+++ b/clients/ethereum/client.go
@@ -148,7 +148,7 @@ func (c *client) GetBatch(ctx context.Context, nonce uint64) (*clients.TransferB
 		ID:       batch.Nonce.Uint64(),
 		Deposits: make([]*clients.DepositTransfer, 0, batch.DepositsCount),
 	}
-
+	tokens := make(map[string][]byte)
 	for i := range deposits {
 		deposit := deposits[i]
 		toBytes := deposit.Recipient[:]
@@ -165,10 +165,15 @@ func (c *client) GetBatch(ctx context.Context, nonce uint64) (*clients.TransferB
 			DisplayableToken: c.addressConverter.ToHexString(tokenBytes),
 			Amount:           big.NewInt(0).Set(deposit.Amount),
 		}
-
-		depositTransfer.ConvertedTokenBytes, err = c.tokensMapper.ConvertToken(ctx, depositTransfer.TokenBytes)
-		if err != nil {
-			return nil, err
+		contractAddress, exists := tokens[depositTransfer.DisplayableToken]
+		if !exists {
+			depositTransfer.ConvertedTokenBytes, err = c.tokensMapper.ConvertToken(ctx, depositTransfer.TokenBytes)
+			if err != nil {
+				return nil, err
+			}
+			tokens[depositTransfer.DisplayableToken] = depositTransfer.ConvertedTokenBytes
+		} else {
+			depositTransfer.ConvertedTokenBytes = contractAddress
 		}
 
 		transferBatch.Deposits = append(transferBatch.Deposits, depositTransfer)

--- a/clients/gasManagement/types_test.go
+++ b/clients/gasManagement/types_test.go
@@ -19,7 +19,7 @@ func stripSpaces(str string) string {
 	}, str)
 }
 
-func TestMicroserviceResponse_String(t *testing.T) {
+func TestGasStationResponse_String(t *testing.T) {
 	t.Parallel()
 
 	response := &gasStationResponse{

--- a/clients/gasManagement/types_test.go
+++ b/clients/gasManagement/types_test.go
@@ -1,0 +1,53 @@
+package gasManagement
+
+import (
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func stripSpaces(str string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			// if the character is a space, drop it
+			return -1
+		}
+		// else keep it in the string
+		return r
+	}, str)
+}
+
+func TestMicroserviceResponse_String(t *testing.T) {
+	t.Parallel()
+
+	response := &gasStationResponse{
+		Fast:        370,
+		Fastest:     400,
+		SafeLow:     270,
+		Average:     300,
+		BlockTime:   15.380281690140846,
+		BlockNum:    14460250,
+		Speed:       0.5719409845737478,
+		SafeLowWait: 17.5,
+		AvgWait:     3.1,
+		FastWait:    0.5,
+		FastestWait: 0.5,
+	}
+	expectedTrueString := `{
+		"fast": 370,
+		"fastest": 400,
+		"safeLow": 270,
+		"average": 300,
+		"block_time": 15.380281690140846,
+		"blockNum": 14460250,
+		"speed": 0.5719409845737478,
+		"safeLowWait": 17.5,
+		"avgWait": 3.1,
+		"fastWait": 0.5,
+		"fastestWait": 0.5
+	}`
+
+	assert.Equal(t, stripSpaces(expectedTrueString), stripSpaces(response.String()))
+}


### PR DESCRIPTION
- convert batch as json from bytes to string before logging
- use fmt.Sprintf instead of string concatenation when declaring requestURL
- add gasStationResponse unit test
- using an internal map for storing the already coverted tokens in order to reduce SC queries