### PR TITLE
Relayer fixes

### DIFF
--- a/clients/elrond/client.go
+++ b/clients/elrond/client.go
@@ -267,6 +267,11 @@ func (c *client) ProposeSetStatus(ctx context.Context, batch *clients.TransferBa
 		return "", clients.ErrNilBatch
 	}
 
+	err := c.checkIsPaused(ctx)
+	if err != nil {
+		return "", err
+	}
+
 	txBuilder := c.createCommonTxDataBuilder(proposeSetStatusFuncName, int64(batch.ID))
 	for _, stat := range batch.Statuses {
 		txBuilder.ArgBytes([]byte{stat})
@@ -285,6 +290,11 @@ func (c *client) ProposeSetStatus(ctx context.Context, batch *clients.TransferBa
 func (c *client) ProposeTransfer(ctx context.Context, batch *clients.TransferBatch) (string, error) {
 	if batch == nil {
 		return "", clients.ErrNilBatch
+	}
+
+	err := c.checkIsPaused(ctx)
+	if err != nil {
+		return "", err
 	}
 
 	txBuilder := c.createCommonTxDataBuilder(proposeTransferFuncName, int64(batch.ID))
@@ -308,6 +318,11 @@ func (c *client) ProposeTransfer(ctx context.Context, batch *clients.TransferBat
 
 // Sign will trigger the execution of a sign operation
 func (c *client) Sign(ctx context.Context, actionID uint64) (string, error) {
+	err := c.checkIsPaused(ctx)
+	if err != nil {
+		return "", err
+	}
+
 	txBuilder := c.createCommonTxDataBuilder(signFuncName, int64(actionID))
 
 	hash, err := c.txHandler.SendTransactionReturnHash(ctx, txBuilder, c.gasMapConfig.Sign)
@@ -324,6 +339,11 @@ func (c *client) PerformAction(ctx context.Context, actionID uint64, batch *clie
 		return "", clients.ErrNilBatch
 	}
 
+	err := c.checkIsPaused(ctx)
+	if err != nil {
+		return "", err
+	}
+
 	txBuilder := c.createCommonTxDataBuilder(performActionFuncName, int64(actionID))
 
 	gasLimit := c.gasMapConfig.PerformActionBase + uint64(len(batch.Statuses))*c.gasMapConfig.PerformActionForEach
@@ -334,6 +354,18 @@ func (c *client) PerformAction(ctx context.Context, actionID uint64, batch *clie
 	}
 
 	return hash, err
+}
+
+func (c *client) checkIsPaused(ctx context.Context) error {
+	isPaused, err := c.IsPaused(ctx)
+	if err != nil {
+		return fmt.Errorf("%w in client.ExecuteTransfer", err)
+	}
+	if isPaused {
+		return fmt.Errorf("%w in client.ExecuteTransfer", clients.ErrMultisigContractPaused)
+	}
+
+	return nil
 }
 
 // CheckClientAvailability will check the client availability and will set the metric accordingly

--- a/clients/elrond/client.go
+++ b/clients/elrond/client.go
@@ -343,7 +343,7 @@ func (c *client) CheckClientAvailability(ctx context.Context) error {
 
 	currentNonce, err := c.GetCurrentNonce(ctx)
 	if err != nil {
-		c.setStatusForAvailabilityCheck(ethElrond.Unavailable, err.Error())
+		c.setStatusForAvailabilityCheck(ethElrond.Unavailable, err.Error(), currentNonce)
 
 		return err
 	}
@@ -358,12 +358,12 @@ func (c *client) CheckClientAvailability(ctx context.Context) error {
 
 	if c.retriesAvailabilityCheck > c.allowDelta {
 		message := fmt.Sprintf("nonce %d fetched for %d times in a row", currentNonce, c.retriesAvailabilityCheck)
-		c.setStatusForAvailabilityCheck(ethElrond.Unavailable, message)
+		c.setStatusForAvailabilityCheck(ethElrond.Unavailable, message, currentNonce)
 
 		return nil
 	}
 
-	c.setStatusForAvailabilityCheck(ethElrond.Available, "")
+	c.setStatusForAvailabilityCheck(ethElrond.Available, "", currentNonce)
 
 	return nil
 }
@@ -372,9 +372,10 @@ func (c *client) incrementRetriesAvailabilityCheck() {
 	c.retriesAvailabilityCheck++
 }
 
-func (c *client) setStatusForAvailabilityCheck(status ethElrond.ClientStatus, message string) {
+func (c *client) setStatusForAvailabilityCheck(status ethElrond.ClientStatus, message string, nonce uint64) {
 	c.statusHandler.SetStringMetric(bridgeCore.MetricElrondClientStatus, status.String())
 	c.statusHandler.SetStringMetric(bridgeCore.MetricLastElrondClientError, message)
+	c.statusHandler.SetIntMetric(bridgeCore.MetricLastBlockNonce, int(nonce))
 }
 
 // Close will close any started go routines. It returns nil.

--- a/clients/elrond/client_test.go
+++ b/clients/elrond/client_test.go
@@ -620,6 +620,7 @@ func TestClient_CheckClientAvailability(t *testing.T) {
 			assert.Nil(t, err)
 			checkStatusHandler(t, statusHandler, ethElrond.Available, "")
 		}
+		assert.True(t, statusHandler.GetIntMetric(bridgeCore.MetricLastBlockNonce) > 0)
 	})
 	t.Run("same current nonce should error after a while", func(t *testing.T) {
 		resetClient(c)
@@ -694,6 +695,7 @@ func resetClient(c *client) {
 	c.mut.Unlock()
 	c.statusHandler.SetStringMetric(bridgeCore.MetricElrondClientStatus, "")
 	c.statusHandler.SetStringMetric(bridgeCore.MetricLastElrondClientError, "")
+	c.statusHandler.SetIntMetric(bridgeCore.MetricLastBlockNonce, 0)
 }
 
 func checkStatusHandler(t *testing.T, statusHandler *testsCommon.StatusHandlerMock, status ethElrond.ClientStatus, message string) {

--- a/clients/elrond/dataGetter.go
+++ b/clients/elrond/dataGetter.go
@@ -85,11 +85,12 @@ func (dg *elrondClientDataGetter) ExecuteQueryReturningBytes(ctx context.Context
 	response, err := dg.proxy.ExecuteVMQuery(ctx, request)
 	if err != nil {
 		dg.log.Error("got error on VMQuery", "FuncName", request.FuncName,
-			"Args", request.Args, "SC address", request.Address, "Caller", request.CallerAddr)
+			"Args", request.Args, "SC address", request.Address, "Caller", request.CallerAddr, "error", err)
 		return nil, err
 	}
 	dg.log.Debug("executed VMQuery", "FuncName", request.FuncName,
 		"Args", request.Args, "SC address", request.Address, "Caller", request.CallerAddr,
+		"response.ReturnCode", response.Data.ReturnCode,
 		"response.ReturnData", fmt.Sprintf("%+v", response.Data.ReturnData))
 	if response.Data.ReturnCode != okCodeAfterExecution {
 		return nil, NewQueryResponseError(

--- a/clients/elrond/dataGetter.go
+++ b/clients/elrond/dataGetter.go
@@ -32,6 +32,7 @@ const (
 	getLastExecutedEthTxId                                    = "getLastExecutedEthTxId"
 	signedFuncName                                            = "signed"
 	getAllStakedRelayersFuncName                              = "getAllStakedRelayers"
+	isPausedFuncName                                          = "isPaused"
 )
 
 // ArgsDataGetter is the arguments DTO used in the NewDataGetter constructor
@@ -399,6 +400,14 @@ func (dg *elrondClientDataGetter) GetAllStakedRelayers(ctx context.Context) ([][
 	builder.Function(getAllStakedRelayersFuncName)
 
 	return dg.executeQueryFromBuilder(ctx, builder)
+}
+
+// IsPaused returns true if the multisig contract is paused
+func (dg *elrondClientDataGetter) IsPaused(ctx context.Context) (bool, error) {
+	builder := dg.createDefaultVmQueryBuilder()
+	builder.Function(isPausedFuncName)
+
+	return dg.executeQueryBoolFromBuilder(ctx, builder)
 }
 
 func getStatusFromBuff(buff []byte) (byte, error) {

--- a/clients/elrond/errors.go
+++ b/clients/elrond/errors.go
@@ -16,6 +16,7 @@ var (
 	errNilRoleProvider          = errors.New("nil role provider")
 	errRelayerNotWhitelisted    = errors.New("relayer not whitelisted")
 	errNilNodeStatusResponse    = errors.New("nil node status response")
+	errContractPaused           = errors.New("contract paused")
 
 	// ErrNoPendingBatchAvailable signals that no pending batch is available
 	ErrNoPendingBatchAvailable = errors.New("no pending batch available")

--- a/clients/elrond/errors.go
+++ b/clients/elrond/errors.go
@@ -16,7 +16,6 @@ var (
 	errNilRoleProvider          = errors.New("nil role provider")
 	errRelayerNotWhitelisted    = errors.New("relayer not whitelisted")
 	errNilNodeStatusResponse    = errors.New("nil node status response")
-	errContractPaused           = errors.New("contract paused")
 
 	// ErrNoPendingBatchAvailable signals that no pending batch is available
 	ErrNoPendingBatchAvailable = errors.New("no pending batch available")

--- a/clients/errors.go
+++ b/clients/errors.go
@@ -26,4 +26,7 @@ var (
 
 	// ErrNilAddressConverter signals that a nil address converter was provided
 	ErrNilAddressConverter = errors.New("nil address converter")
+
+	// ErrMultisigContractPaused signals that the multisig contract is paused
+	ErrMultisigContractPaused = errors.New("multisig contract paused")
 )

--- a/clients/ethereum/client.go
+++ b/clients/ethereum/client.go
@@ -307,6 +307,14 @@ func (c *client) ExecuteTransfer(
 		return "", clients.ErrNilBatch
 	}
 
+	isPaused, err := c.clientWrapper.IsPaused(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%w in client.ExecuteTransfer", err)
+	}
+	if isPaused {
+		return "", fmt.Errorf("%w in client.ExecuteTransfer", clients.ErrMultisigContractPaused)
+	}
+
 	c.log.Info("executing transfer " + batch.String())
 
 	fromAddress := crypto.PubkeyToAddress(*c.publicKey)

--- a/clients/ethereum/client.go
+++ b/clients/ethereum/client.go
@@ -383,7 +383,7 @@ func (c *client) CheckClientAvailability(ctx context.Context) error {
 
 	currentBlock, err := c.clientWrapper.BlockNumber(ctx)
 	if err != nil {
-		c.setStatusForAvailabilityCheck(ethElrond.Unavailable, err.Error())
+		c.setStatusForAvailabilityCheck(ethElrond.Unavailable, err.Error(), currentBlock)
 
 		return err
 	}
@@ -398,12 +398,12 @@ func (c *client) CheckClientAvailability(ctx context.Context) error {
 
 	if c.retriesAvailabilityCheck > c.allowDelta {
 		message := fmt.Sprintf("block %d fetched for %d times in a row", currentBlock, c.retriesAvailabilityCheck)
-		c.setStatusForAvailabilityCheck(ethElrond.Unavailable, message)
+		c.setStatusForAvailabilityCheck(ethElrond.Unavailable, message, currentBlock)
 
 		return nil
 	}
 
-	c.setStatusForAvailabilityCheck(ethElrond.Available, "")
+	c.setStatusForAvailabilityCheck(ethElrond.Available, "", currentBlock)
 
 	return nil
 }
@@ -412,9 +412,10 @@ func (c *client) incrementRetriesAvailabilityCheck() {
 	c.retriesAvailabilityCheck++
 }
 
-func (c *client) setStatusForAvailabilityCheck(status ethElrond.ClientStatus, message string) {
+func (c *client) setStatusForAvailabilityCheck(status ethElrond.ClientStatus, message string, nonce uint64) {
 	c.clientWrapper.SetStringMetric(core.MetricElrondClientStatus, status.String())
 	c.clientWrapper.SetStringMetric(core.MetricLastElrondClientError, message)
+	c.clientWrapper.SetIntMetric(core.MetricLastBlockNonce, int(nonce))
 }
 
 func (c *client) checkAvailableTokens(ctx context.Context, tokens []common.Address, amounts []*big.Int) error {

--- a/clients/ethereum/client_test.go
+++ b/clients/ethereum/client_test.go
@@ -814,6 +814,7 @@ func TestClient_CheckClientAvailability(t *testing.T) {
 			assert.Nil(t, err)
 			checkStatusHandler(t, statusHandler, ethElrond.Available, "")
 		}
+		assert.True(t, statusHandler.GetIntMetric(bridgeCore.MetricLastBlockNonce) > 0)
 	})
 	t.Run("same current nonce should error after a while", func(t *testing.T) {
 		resetClient(c)

--- a/clients/ethereum/client_test.go
+++ b/clients/ethereum/client_test.go
@@ -431,6 +431,29 @@ func TestClient_ExecuteTransfer(t *testing.T) {
 		assert.Equal(t, "", hash)
 		assert.True(t, errors.Is(err, clients.ErrNilBatch))
 	})
+	t.Run("check if the contract is paused fails", func(t *testing.T) {
+		expectedErr := errors.New("expected error is paused")
+		c, _ := NewEthereumClient(args)
+		c.clientWrapper = &bridgeTests.EthereumClientWrapperStub{
+			IsPausedCalled: func(ctx context.Context) (bool, error) {
+				return false, expectedErr
+			},
+		}
+		hash, err := c.ExecuteTransfer(context.Background(), common.Hash{}, batch, 10)
+		assert.Equal(t, "", hash)
+		assert.True(t, errors.Is(err, expectedErr))
+	})
+	t.Run("contract is paused should error", func(t *testing.T) {
+		c, _ := NewEthereumClient(args)
+		c.clientWrapper = &bridgeTests.EthereumClientWrapperStub{
+			IsPausedCalled: func(ctx context.Context) (bool, error) {
+				return true, nil
+			},
+		}
+		hash, err := c.ExecuteTransfer(context.Background(), common.Hash{}, batch, 10)
+		assert.Equal(t, "", hash)
+		assert.True(t, errors.Is(err, clients.ErrMultisigContractPaused))
+	})
 	t.Run("get block number fails", func(t *testing.T) {
 		expectedErr := errors.New("expected error get block number")
 		c, _ := NewEthereumClient(args)

--- a/clients/ethereum/interface.go
+++ b/clients/ethereum/interface.go
@@ -27,6 +27,7 @@ type ClientWrapper interface {
 	Quorum(ctx context.Context) (*big.Int, error)
 	GetStatusesAfterExecution(ctx context.Context, batchID *big.Int) ([]byte, error)
 	BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error)
+	IsPaused(ctx context.Context) (bool, error)
 }
 
 // Erc20ContractsHolder defines the Ethereum ERC20 contract operations

--- a/clients/ethereum/wrappers/ethereumChainWrapper.go
+++ b/clients/ethereum/wrappers/ethereumChainWrapper.go
@@ -128,6 +128,11 @@ func (wrapper *ethereumChainWrapper) BalanceAt(ctx context.Context, account comm
 	return wrapper.blockchainClient.BalanceAt(ctx, account, blockNumber)
 }
 
+// IsPaused returns true if the multisig contract is paused
+func (wrapper *ethereumChainWrapper) IsPaused(ctx context.Context) (bool, error) {
+	return wrapper.multiSigContract.Paused(&bind.CallOpts{Context: ctx})
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
 func (wrapper *ethereumChainWrapper) IsInterfaceNil() bool {
 	return wrapper == nil

--- a/clients/ethereum/wrappers/ethereumChainWrapper_test.go
+++ b/clients/ethereum/wrappers/ethereumChainWrapper_test.go
@@ -275,3 +275,22 @@ func TestEthClientWrapper_GetStatusesAfterExecution(t *testing.T) {
 	assert.True(t, handlerCalled)
 	assert.Equal(t, 1, statusHandler.GetIntMetric(core.MetricNumEthClientRequests))
 }
+
+func TestEthereumChainWrapper_IsPaused(t *testing.T) {
+	t.Parallel()
+
+	args, _ := createMockArgsEthereumChainWrapper()
+	handlerCalled := false
+	args.MultiSigContract = &bridgeTests.MultiSigContractStub{
+		PausedCalled: func(opts *bind.CallOpts) (bool, error) {
+			handlerCalled = true
+			return true, nil
+		},
+	}
+	wrapper, _ := NewEthereumChainWrapper(args)
+	result, err := wrapper.IsPaused(context.Background())
+
+	assert.Nil(t, err)
+	assert.True(t, result)
+	assert.True(t, handlerCalled)
+}

--- a/clients/ethereum/wrappers/interface.go
+++ b/clients/ethereum/wrappers/interface.go
@@ -22,6 +22,7 @@ type multiSigContract interface {
 	ExecuteTransfer(opts *bind.TransactOpts, tokens []common.Address, recipients []common.Address, amounts []*big.Int, depositNonces []*big.Int, batchNonce *big.Int, signatures [][]byte) (*types.Transaction, error)
 	Quorum(opts *bind.CallOpts) (*big.Int, error)
 	GetStatusesAfterExecution(opts *bind.CallOpts, batchID *big.Int) ([]byte, error)
+	Paused(opts *bind.CallOpts) (bool, error)
 }
 
 type blockchainClient interface {

--- a/clients/gasManagement/factory/gasManagementFactory_test.go
+++ b/clients/gasManagement/factory/gasManagementFactory_test.go
@@ -17,6 +17,7 @@ func createMockArgsGasStation() gasManagement.ArgsGasStation {
 		RequestTime:            time.Second,
 		MaximumGasPrice:        1000,
 		GasPriceSelector:       "fast",
+		GasPriceMultiplier:     1,
 	}
 }
 

--- a/clients/gasManagement/gasStation_test.go
+++ b/clients/gasManagement/gasStation_test.go
@@ -24,6 +24,7 @@ func createMockArgsGasStation() ArgsGasStation {
 		RequestTime:            time.Second,
 		MaximumGasPrice:        1000,
 		GasPriceSelector:       "fast",
+		GasPriceMultiplier:     100000000,
 	}
 }
 
@@ -55,6 +56,15 @@ func TestNewGasStation(t *testing.T) {
 		gs, err := NewGasStation(args)
 		assert.True(t, check.IfNil(gs))
 		assert.True(t, errors.Is(err, ErrInvalidGasPriceSelector))
+	})
+	t.Run("invalid gas price multiplier", func(t *testing.T) {
+		args := createMockArgsGasStation()
+		args.GasPriceMultiplier = 0
+
+		gs, err := NewGasStation(args)
+		assert.True(t, check.IfNil(gs))
+		assert.True(t, errors.Is(err, clients.ErrInvalidValue))
+		assert.True(t, strings.Contains(err.Error(), "checkArgs for value GasPriceMultiplier"))
 	})
 	t.Run("should work", func(t *testing.T) {
 		args := createMockArgsGasStation()
@@ -178,6 +188,7 @@ func TestGasStation_GetCurrentGasPrice(t *testing.T) {
 		FastestWait: 11,
 	}
 	args := createMockArgsGasStation()
+	gasPriceMultiplier := big.NewInt(int64(args.GasPriceMultiplier))
 	httpServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 

--- a/cmd/bridge/config/config.toml
+++ b/cmd/bridge/config/config.toml
@@ -3,18 +3,20 @@
     MultisigContractAddress = "3009d97FfeD62E57d444e552A9eDF9Ee6Bc8644c" # the eth address for the bridge contract
     SafeContractAddress = "A6504Cc508889bbDBd4B748aFf6EA6b5D0d2684c"
     PrivateKeyFile = "keys/ethereum.sk" # the path to the file containing the relayer eth private key
-    GasLimitBase = 200000
+    GasLimitBase = 350000
     GasLimitForEach = 30000
     IntervalToWaitForTransferInSeconds = 600 #10 minutes
     MaxRetriesOnQuorumReached = 3
+    MaxBlocksDelta = 10
     [Eth.GasStation]
         Enabled = true
         URL = "https://ethgasstation.info/api/ethgasAPI.json?" # gas station URL. Suggestion to provide the api-key here
+        GasPriceMultiplier = 100000000 # the value to be multiplied with the fetched value. Useful in test chains. On production chain should be 100000000
         PollingIntervalInSeconds = 60 # number of seconds between gas price polling
         RequestTimeInSeconds = 2 # maximum timeout (in seconds) for the gas price request
         MaximumAllowedGasPrice = 3000 # maximum value allowed for the fetched gas price value
         # GasPriceSelector available options: "fast", "fastest", "safeLow", "average"
-        GasPriceSelector = "safeLow" # selector used to provide the gas price
+        GasPriceSelector = "fastest" # selector used to provide the gas price
 
 [Elrond]
     NetworkAddress = "https://devnet-gateway.elrond.com" # the network address
@@ -33,11 +35,11 @@
     [Elrond.GasMap]
         Sign = 8000000
         ProposeTransferBase = 11000000
-        ProposeTransferForEach = 3000000
+        ProposeTransferForEach = 5500000
         ProposeStatusBase = 10000000
         ProposeStatusForEach = 7000000
-        PerformActionBase = 25000000
-        PerformActionForEach = 2000000
+        PerformActionBase = 40000000
+        PerformActionForEach = 5500000
 
 [P2P]
     Port = "10010"
@@ -130,7 +132,7 @@
         IntervalForLeaderInSeconds = 120 #2 minutes
 
     [StateMachine.ElrondToEth]
-        StepDurationInMillis = 12000
+        StepDurationInMillis = 12000 #12 seconds
         IntervalForLeaderInSeconds = 720 #12 minutes
 
 [Logs]

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -219,16 +219,17 @@ func startRelay(ctx *cli.Context, version string) error {
 	}
 
 	args := factory.ArgsEthereumToElrondBridge{
-		Configs:              configs,
-		Messenger:            messenger,
-		StatusStorer:         statusStorer,
-		Proxy:                proxy,
-		Erc20ContractsHolder: erc20ContractsHolder,
-		ClientWrapper:        clientWrapper,
-		TimeForBootstrap:     timeForBootstrap,
-		TimeBeforeRepeatJoin: timeBeforeRepeatJoin,
-		MetricsHolder:        metricsHolder,
-		AppStatusHandler:     appStatusHandler.StatusHandler(),
+		Configs:                   configs,
+		Messenger:                 messenger,
+		StatusStorer:              statusStorer,
+		Proxy:                     proxy,
+		Erc20ContractsHolder:      erc20ContractsHolder,
+		ClientWrapper:             clientWrapper,
+		TimeForBootstrap:          timeForBootstrap,
+		TimeBeforeRepeatJoin:      timeBeforeRepeatJoin,
+		MetricsHolder:             metricsHolder,
+		AppStatusHandler:          appStatusHandler.StatusHandler(),
+		ElrondClientStatusHandler: elrondClientStatusHandler,
 	}
 
 	ethToElrondComponents, err := factory.NewEthElrondBridgeComponents(args)

--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,7 @@ type GasStationConfig struct {
 	RequestTimeInSeconds     int
 	MaximumAllowedGasPrice   int
 	GasPriceSelector         string
+	GasPriceMultiplier       int
 }
 
 // ConfigP2P configuration for the P2P communication

--- a/core/constants.go
+++ b/core/constants.go
@@ -58,12 +58,15 @@ const (
 
 	// MetricConnectedP2PAddresses represents the metric used to store all the P2P addresses the messenger has connected to
 	MetricConnectedP2PAddresses = "connected P2P addresses"
+
+	// MetricLastBlockNonce represents the last block nonce queried
+	MetricLastBlockNonce = "last block nonce"
 )
 
 // PersistedMetrics represents the array of metrics that should be persisted
 var PersistedMetrics = []string{MetricNumBatches, MetricNumEthClientRequests, MetricNumEthClientTransactions,
 	MetricLastQueriedEthereumBlockNumber, MetricLastQueriedElrondBlockNumber, MetricEthereumClientStatus,
-	MetricElrondClientStatus, MetricLastEthereumClientError, MetricLastElrondClientError}
+	MetricElrondClientStatus, MetricLastEthereumClientError, MetricLastElrondClientError, MetricLastBlockNonce}
 
 const (
 	// EthClientStatusHandlerName is the ethereum client status handler name

--- a/factory/ethElrondBridgeComponents.go
+++ b/factory/ethElrondBridgeComponents.go
@@ -316,6 +316,7 @@ func (components *ethElrondBridgeComponents) createEthereumClient(args ArgsEther
 		RequestTime:            time.Duration(gasStationConfig.RequestTimeInSeconds) * time.Second,
 		MaximumGasPrice:        gasStationConfig.MaximumAllowedGasPrice,
 		GasPriceSelector:       core.EthGasPriceSelector(gasStationConfig.GasPriceSelector),
+		GasPriceMultiplier:     gasStationConfig.GasPriceMultiplier,
 	}
 
 	gs, err := factory.CreateGasStation(argsGasStation, gasStationConfig.Enabled)

--- a/factory/ethElrondBridgeComponents_test.go
+++ b/factory/ethElrondBridgeComponents_test.go
@@ -44,6 +44,7 @@ func createMockEthElrondBridgeArgs() ArgsEthereumToElrondBridge {
 				RequestTimeInSeconds:     1,
 				MaximumAllowedGasPrice:   1000,
 				GasPriceSelector:         "fast",
+				GasPriceMultiplier:       1,
 			},
 			MaxRetriesOnQuorumReached:          1,
 			IntervalToWaitForTransferInSeconds: 1,

--- a/integrationTests/mock/elrondContractStateMock.go
+++ b/integrationTests/mock/elrondContractStateMock.go
@@ -247,6 +247,8 @@ func (mock *elrondContractStateMock) processVmRequests(vmRequest *data.VmValueRe
 		return mock.vmRequestGetLastExecutedEthTxId(vmRequest), nil
 	case "signed":
 		return mock.vmRequestSigned(vmRequest), nil
+	case "isPaused":
+		return mock.vmRequestIsPaused(vmRequest), nil
 	}
 
 	panic("unimplemented function: " + vmRequest.FuncName)
@@ -444,10 +446,14 @@ func (mock *elrondContractStateMock) vmRequestSigned(request *data.VmValueReques
 	address := data.NewAddressFromBytes(addressBytes)
 	_, found = actionIDMap[address.AddressAsBech32String()]
 	if !found {
-		log.Error("not found")
+		log.Error("action ID not found", "address", address.AddressAsBech32String())
 	}
 
 	return createOkVmResponse([][]byte{BoolToByteSlice(found)})
+}
+
+func (mock *elrondContractStateMock) vmRequestIsPaused(_ *data.VmValueRequest) *data.VmValuesResponseData {
+	return createOkVmResponse([][]byte{BoolToByteSlice(false)})
 }
 
 func getActionIDFromString(data string) *big.Int {

--- a/integrationTests/mock/ethereumChainMock.go
+++ b/integrationTests/mock/ethereumChainMock.go
@@ -252,6 +252,11 @@ func (mock *EthereumChainMock) BalanceAt(ctx context.Context, account common.Add
 	return big.NewInt(0), nil
 }
 
+// IsPaused -
+func (mock *EthereumChainMock) IsPaused(_ context.Context) (bool, error) {
+	return false, nil
+}
+
 // IsInterfaceNil -
 func (mock *EthereumChainMock) IsInterfaceNil() bool {
 	return mock == nil

--- a/testsCommon/bridge/ethereumClientWrapperStub.go
+++ b/testsCommon/bridge/ethereumClientWrapperStub.go
@@ -33,6 +33,7 @@ type EthereumClientWrapperStub struct {
 	SetStringMetricCalled func(metric string, val string)
 	GetAllMetricsCalled   func() core.GeneralMetrics
 	NameCalled            func() string
+	IsPausedCalled        func(ctx context.Context) (bool, error)
 }
 
 // SetIntMetric -
@@ -186,6 +187,15 @@ func (stub *EthereumClientWrapperStub) BalanceAt(ctx context.Context, account co
 	}
 
 	return big.NewInt(0), nil
+}
+
+// IsPaused -
+func (stub *EthereumClientWrapperStub) IsPaused(ctx context.Context) (bool, error) {
+	if stub.IsPausedCalled != nil {
+		return stub.IsPausedCalled(ctx)
+	}
+
+	return false, nil
 }
 
 // IsInterfaceNil -

--- a/testsCommon/bridge/multiSigContractStub.go
+++ b/testsCommon/bridge/multiSigContractStub.go
@@ -19,6 +19,7 @@ type MultiSigContractStub struct {
 		amounts []*big.Int, nonces []*big.Int, batchNonce *big.Int, signatures [][]byte) (*types.Transaction, error)
 	QuorumCalled                    func(opts *bind.CallOpts) (*big.Int, error)
 	GetStatusesAfterExecutionCalled func(opts *bind.CallOpts, batchID *big.Int) ([]byte, error)
+	PausedCalled                    func(opts *bind.CallOpts) (bool, error)
 }
 
 // GetBatch -
@@ -90,4 +91,13 @@ func (stub *MultiSigContractStub) GetStatusesAfterExecution(opts *bind.CallOpts,
 	}
 
 	return make([]byte, 0), nil
+}
+
+// Paused -
+func (stub *MultiSigContractStub) Paused(opts *bind.CallOpts) (bool, error) {
+	if stub.PausedCalled != nil {
+		return stub.PausedCalled(opts)
+	}
+
+	return false, nil
 }


### PR DESCRIPTION
- fixed node starting
- extracted gas multiplier in config
- added new metrics
- prevent relayers to send transactions if the contracts are paused